### PR TITLE
[PLATFORM-1960] Add topics to repository

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,6 @@
+
+repository:
+  # See https://github.com/apps/settings for all available settings.
+  name: tdd-password-validator
+  description: null
+  topics: "squad::Deposits, mission::Deposits, product::Retail Deposits, environment::Sandbox"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,4 +3,4 @@ repository:
   # See https://github.com/apps/settings for all available settings.
   name: tdd-password-validator
   description: null
-  topics: "squad::Deposits, mission::Deposits, product::Retail Deposits, environment::Sandbox"
+  topics: squad-deposits, mission-deposits, product-retail-deposits, environment-sandbox


### PR DESCRIPTION
In order to easily group GitHub repositories together, we utilise topics to act as labels. We assign a squad to each repository to act as the main point of contact. Read more here: https://oaknorth-bank.atlassian.net/wiki/spaces/ENG/pages/287670416/GitHub+Topics